### PR TITLE
Cmdc 114 fix kubernetes storage

### DIFF
--- a/.docker/Dockerfile.postgres.staging
+++ b/.docker/Dockerfile.postgres.staging
@@ -1,0 +1,3 @@
+FROM postgres:12-alpine
+
+RUN mkdir -p /var/lib/postgresql/data/k8s

--- a/.docker/pvc-k8s/solr-data-staging.yaml
+++ b/.docker/pvc-k8s/solr-data-staging.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: solr-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+#  storageClassName: rook-ceph-block
+  resources:
+    requests:
+      storage: 50Gi
+status: {}

--- a/.docker/remote-k8s/db-deployment-staging.yaml
+++ b/.docker/remote-k8s/db-deployment-staging.yaml
@@ -30,13 +30,15 @@ spec:
               value: arclight
             - name: POSTGRES_PASSWORD
               value: arclight
-          image: postgres:12-alpine
+            - name: PGDATA
+              value: /var/lib/postgresql/data/k8s
+          image: ghcr.io/mlibrary/arclight/postgres
           name: db
           ports:
             - containerPort: 5432
           resources: {}
           volumeMounts:
-            - mountPath: /var/lib/postgresql
+            - mountPath: /var/lib/postgresql/data
               name: pg-data
       restartPolicy: Always
       volumes:

--- a/.docker/remote-k8s/resque-deployment-staging.yaml
+++ b/.docker/remote-k8s/resque-deployment-staging.yaml
@@ -45,7 +45,7 @@ spec:
               value: redis://redis:6379
             - name: SOLR_URL
               value: http://solr:8983/solr/arclight
-          image: estythomas/umich-arclight-staging:20220217.4
+          image: ghcr.io/mlibrary/arclight/umich-arclight-staging:20220217.4
           imagePullPolicy: Always
           name: resque
           ports:

--- a/.docker/remote-k8s/resque-web-deployment-staging.yaml
+++ b/.docker/remote-k8s/resque-web-deployment-staging.yaml
@@ -43,7 +43,7 @@ spec:
               value: redis://redis:6379
             - name: SOLR_URL
               value: http://solr:8983/solr/arclight
-          image: estythomas/umich-arclight-staging:20220217.4
+          image: ghcr.io/mlibrary/arclight/umich-arclight-staging:20220217.4
           imagePullPolicy: Always
           name: resque-web
           ports:

--- a/.docker/remote-k8s/solr-deployment-staging.yaml
+++ b/.docker/remote-k8s/solr-deployment-staging.yaml
@@ -25,11 +25,18 @@ spec:
         io.kompose.service: solr
     spec:
       containers:
-        - image: ghcr.io/mlibrary/arclight/umich-arclight-solr-staging:latest
+        - image: ghcr.io/mlibrary/arclight/umich-arclight-solr-staging:20220418.1
           imagePullPolicy: Always
           name: solr
           ports:
             - containerPort: 8983
           resources: {}
+          volumeMounts:
+            - mountPath: /solr/data
+              name: solr-data
       restartPolicy: Always
+      volumes:
+        - name: solr-data
+          persistentVolumeClaim:
+            claimName: solr-data
 status: {}

--- a/.docker/remote-k8s/solr-deployment-staging.yaml
+++ b/.docker/remote-k8s/solr-deployment-staging.yaml
@@ -25,7 +25,7 @@ spec:
         io.kompose.service: solr
     spec:
       containers:
-        - image: estythomas/umich-arclight-solr-staging:20220106.4
+        - image: ghcr.io/mlibrary/arclight/umich-arclight-solr-staging:latest
           imagePullPolicy: Always
           name: solr
           ports:

--- a/solr/arclight/conf/solrconfig.xml
+++ b/solr/arclight/conf/solrconfig.xml
@@ -46,7 +46,7 @@
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 
 
-  <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
+  <dataDir>/solr/data/${solr.core.name}</dataDir>
 
   <requestDispatcher handleSelect="true" >
     <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048" />


### PR DESCRIPTION
We were having an issue where certain deployments would nuke the database and/or the solr index. These changes cause the kubernetes deployment to actually use persistent volumes for storing data which we would prefer remain persisted.