### PR TITLE
suppress Levels facet in search results

### DIFF
--- a/.github/workflows/build-development-branch.yml
+++ b/.github/workflows/build-development-branch.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ suppress_levels_facet ]
 jobs:
-  build:
+  build-testing:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,7 +29,7 @@ jobs:
           file: .docker/Dockerfile.staging
 
   deploy-testing-app:
-    needs: build
+    needs: build-testing
     runs-on: ubuntu-latest
     environment: testing
     steps:
@@ -47,7 +47,7 @@ jobs:
           container: app
 
   deploy-testing-resque:
-    needs: build
+    needs: build-testing
     runs-on: ubuntu-latest
     environment: testing
     steps:

--- a/.github/workflows/build-development-branch.yml
+++ b/.github/workflows/build-development-branch.yml
@@ -2,7 +2,7 @@ name: Build latest from whatever side branch
 
 on:
   push:
-    branches: [ cmdc-148_indexing-issues ]
+    branches: [ suppress_levels_facet ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-umich-develop.yml
+++ b/.github/workflows/build-umich-develop.yml
@@ -5,7 +5,7 @@ on:
     branches: [ umich_develop ] # umich_develop is effectively our main branch
 
 jobs:
-  build:
+  build-staging:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,7 +30,7 @@ jobs:
           file: .docker/Dockerfile.staging
 
   deploy-staging-resque:
-    needs: build
+    needs: build-staging
     runs-on: ubuntu-latest
     environment: staging
     steps:
@@ -48,7 +48,7 @@ jobs:
           container: resque
 
   deploy-staging-app:
-    needs: build
+    needs: build-staging
     runs-on: ubuntu-latest
     environment: staging
     steps:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -123,7 +123,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creator_ssim', label: 'Creator', show: false
     config.add_facet_field 'creators_ssim', label: 'Creator', limit: 10
     config.add_facet_field 'date_range_sim', label: 'Date range', range: true
-    config.add_facet_field 'level_sim', label: 'Level', limit: 10
+    config.add_facet_field 'level_sim', label: 'Level', show: false
     config.add_facet_field 'names_ssim', label: 'Names', limit: 10
     config.add_facet_field 'repository_sim', label: 'Repository', limit: 10
     config.add_facet_field 'places_ssim', label: 'Place', limit: 10


### PR DESCRIPTION
doesn't make sense, is inconsistent

this is used to browse collections, so I am simply not showing it
instead of not having it at all