### PR TITLE
Add Aeon fields for Bentley

### DIFF
--- a/.github/workflows/build-development-branch.yml
+++ b/.github/workflows/build-development-branch.yml
@@ -2,7 +2,7 @@ name: Build latest from whatever side branch
 
 on:
   push:
-    branches: [ suppress_levels_facet ]
+    branches: [ cmdc-161_aeon-fields ]
 jobs:
   build-testing:
     runs-on: ubuntu-latest

--- a/app/models/arclight/requests/aeon_hidden_form_request.rb
+++ b/app/models/arclight/requests/aeon_hidden_form_request.rb
@@ -21,7 +21,7 @@ module Arclight
       end
 
       def form_mapping
-        static_mappings.merge(dynamic_mappings)
+        static_mappings.merge(dynamic_mappings).merge(transform_mappings)
       end
 
       def static_mappings
@@ -31,6 +31,14 @@ module Arclight
       def dynamic_mappings
         config['request_mappings']['accessor'].transform_values do |v|
           @document.send(v.to_sym)
+        end
+      end
+
+      def transform_mappings
+        config['request_mappings']['transform'].transform_values do |v|
+          raw = @document.send(v['field'].to_sym)
+          matched = raw.match(v['regex'])
+          matched[1]
         end
       end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -117,6 +117,14 @@ class SolrDocument
     fetch('physdesc_tesim', []).map! { |value| correct_singular_value(value) }
   end
 
+  def physloc
+    fetch('collection_physloc_tesim', [])[0]
+  end
+
+  def collection_date
+    fetch('collection_date_inclusive_ssm', [])[0]
+  end
+
   def is_checkbox_requestable?
     config_present = repository_config.request_config_present_for_type?('aeon_hidden_form_request')
     container_requestable = containers.all? do |container|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -125,6 +125,10 @@ class SolrDocument
     fetch('collection_date_inclusive_ssm', [])[0]
   end
 
+  def collection_creator
+    fetch('collection_creator_ssm', [])[0]
+  end
+
   def is_checkbox_requestable?
     config_present = repository_config.request_config_present_for_type?('aeon_hidden_form_request')
     container_requestable = containers.all? do |container|

--- a/app/views/catalog/_aeon_request_checkbox.html.erb
+++ b/app/views/catalog/_aeon_request_checkbox.html.erb
@@ -12,5 +12,6 @@
     <input type="hidden" name="ItemSubTitle_<%= document.id %>" value="<%= raw(strip_tags(document.normalized_title)) %> (<%= document.extent %>)">
     <input type="hidden" name="ItemVolume_<%= document.id %>" value="<%= document.containers.join(', ') %>">
     <input type="hidden" name="ItemCitation_<%= document.id %>" value="<%= document.reference %>">
+    <input type="hidden" name="ItemInfo1" value="<%= document.accessrestrict %>">
   </label>
 </div>

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -28,6 +28,7 @@ bhl:
           CallNumber: collection_unitid
           SubLocation: physloc
           ItemDate: collection_date
+          ItemAuthor: collection_creator
 scrc:
   name: 'University of Michigan. Special Collections Research Center'
   description: 'In keeping with the University Library’s mission to collect, describe, preserve, and make available the record of human knowledge, the Special Collections Research Center acquires, cares for, interprets, and promotes the use of important collections of unique, rare, primary source, and other material in all formats and in a variety of subject areas.'

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -26,6 +26,8 @@ bhl:
           ItemTitle: collection_name
           idno: eadid
           CallNumber: collection_unitid
+          SubLocation: physloc
+          ItemDate: collection_date
 scrc:
   name: 'University of Michigan. Special Collections Research Center'
   description: 'In keeping with the University Library’s mission to collect, describe, preserve, and make available the record of human knowledge, the Special Collections Research Center acquires, cares for, interprets, and promotes the use of important collections of unique, rare, primary source, and other material in all formats and in a variety of subject areas.'

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -21,9 +21,11 @@ bhl:
           Type: 200
         static:
           SystemId: ArcLight
-          ItemInfo1: manuscript
+#          ItemInfo1: manuscript
         accessor:
           ItemTitle: collection_name
+          idno: eadid
+          CallNumber: collection_unitid
 scrc:
   name: 'University of Michigan. Special Collections Research Center'
   description: 'In keeping with the University Library’s mission to collect, describe, preserve, and make available the record of human knowledge, the Special Collections Research Center acquires, cares for, interprets, and promotes the use of important collections of unique, rare, primary source, and other material in all formats and in a variety of subject areas.'

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -29,6 +29,10 @@ bhl:
           SubLocation: physloc
           ItemDate: collection_date
           ItemAuthor: collection_creator
+        transform:
+          ReferenceNumber:
+            field: eadid
+            regex: 'umich-bhl-(.*)'
 scrc:
   name: 'University of Michigan. Special Collections Research Center'
   description: 'In keeping with the University Library’s mission to collect, describe, preserve, and make available the record of human knowledge, the Special Collections Research Center acquires, cares for, interprets, and promotes the use of important collections of unique, rare, primary source, and other material in all formats and in a variety of subject areas.'

--- a/lib/dul_arclight/traject/ead2_config.rb
+++ b/lib/dul_arclight/traject/ead2_config.rb
@@ -141,6 +141,7 @@ to_field 'ead_ssi', extract_xpath('/ead/eadheader/eadid')
 to_field 'unitdate_ssm', extract_xpath('/ead/archdesc/did/unitdate|/ead/archdesc/did/unittitle/unitdate')
 to_field 'unitdate_bulk_ssim', extract_xpath('/ead/archdesc/did/unitdate[@type="bulk"]|/ead/archdesc/did/unittitle/unitdate[@type="bulk"]')
 to_field 'unitdate_inclusive_ssm', extract_xpath('/ead/archdesc/did/unitdate[@type="inclusive"]|/ead/archdesc/did/unittitle/unitdate[@type="inclusive"]')
+to_field 'collection_date_inclusive_ssm', extract_xpath('/ead/archdesc/did/unitdate[@type="inclusive"]|/ead/archdesc/did/unittitle/unitdate[@type="inclusive"]')
 to_field 'unitdate_other_ssim', extract_xpath('/ead/archdesc/did/unitdate[not(@type)]|/ead/archdesc/did/unittitle/unitdate[not(@type)]')
 
 # Aleph ID (esp. for request integration)
@@ -339,6 +340,8 @@ DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_tesim", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
   to_field "#{selector}_teim", extract_xpath("/ead/archdesc/did/#{selector}/*[local-name()!='head']")
 end
+to_field "collection_physloc_tesim", extract_xpath("/ead/archdesc/did/physloc")
+
 
 # DUL CUSTOMIZATION
 RESTRICTION_FIELDS.map do |selector|
@@ -519,6 +522,14 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   to_field 'collection_ssi' do |_record, accumulator, context|
     accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
   end
+
+  to_field 'collection_physloc_tesim' do |_record, accumulator, context|
+    accumulator.concat context.clipboard[:parent].output_hash['collection_physloc_tesim']
+  end
+  to_field 'collection_date_inclusive_ssm' do |_record, accumulator, context|
+    accumulator.concat context.clipboard[:parent].output_hash['collection_date_inclusive_ssm']
+  end
+
 
   to_field 'extent_ssm', extract_xpath('./did/physdesc/extent')
   to_field 'extent_teim', extract_xpath('./did/physdesc/extent')

--- a/lib/dul_arclight/traject/ead2_config.rb
+++ b/lib/dul_arclight/traject/ead2_config.rb
@@ -526,13 +526,22 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   end
 
   to_field 'collection_physloc_tesim' do |_record, accumulator, context|
-    accumulator.concat context.clipboard[:parent].output_hash['collection_physloc_tesim']
+    collection_physloc = context.clipboard[:parent].output_hash['collection_physloc_tesim']
+    if collection_physloc
+      accumulator.concat collection_physloc
+    end
   end
   to_field 'collection_date_inclusive_ssm' do |_record, accumulator, context|
-    accumulator.concat context.clipboard[:parent].output_hash['collection_date_inclusive_ssm']
+    collection_date = context.clipboard[:parent].output_hash['collection_date_inclusive_ssm']
+    if collection_date
+      accumulator.concat collection_date
+    end
   end
   to_field 'collection_creator_ssm' do |_record, accumulator, context|
-    accumulator.concat context.clipboard[:parent].output_hash['collection_creator_ssm']
+    collection_creator = context.clipboard[:parent].output_hash['collection_creator_ssm']
+    if collection_creator
+      accumulator.concat collection_creator
+    end
   end
 
   to_field 'extent_ssm', extract_xpath('./did/physdesc/extent')

--- a/lib/dul_arclight/traject/ead2_config.rb
+++ b/lib/dul_arclight/traject/ead2_config.rb
@@ -242,6 +242,8 @@ to_field 'creators_ssim' do |_record, accumulator, context|
   accumulator.concat context.output_hash['creator_famname_ssm'] if context.output_hash['creator_famname_ssm']
 end
 
+to_field 'collection_creator_ssm', extract_xpath('/ead/archdesc/did/origination[@label="creator"]')
+
 to_field 'places_sim', extract_xpath('/ead/archdesc/controlaccess/geogname|/ead/archdesc/controlaccess/controlaccess/geogname')
 to_field 'places_ssim', extract_xpath('/ead/archdesc/controlaccess/geogname|/ead/archdesc/controlaccess/controlaccess/geogname')
 to_field 'places_ssm', extract_xpath('/ead/archdesc/controlaccess/geogname|/ead/archdesc/controlaccess/controlaccess/geogname')
@@ -529,7 +531,9 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   to_field 'collection_date_inclusive_ssm' do |_record, accumulator, context|
     accumulator.concat context.clipboard[:parent].output_hash['collection_date_inclusive_ssm']
   end
-
+  to_field 'collection_creator_ssm' do |_record, accumulator, context|
+    accumulator.concat context.clipboard[:parent].output_hash['collection_creator_ssm']
+  end
 
   to_field 'extent_ssm', extract_xpath('./did/physdesc/extent')
   to_field 'extent_teim', extract_xpath('./did/physdesc/extent')


### PR DESCRIPTION
Should add the following fields to Aeon requests for Bentley, per [the document they provided](https://docs.google.com/document/d/1YQBIuH7jkrULh6anMx-X3nPFkARN5g8EQYkRvmUmEQo/edit):

- collection level:
    - idno
    - ItemAuthor
    - CallNumber
    - ItemDate
    - SubLocation
    - ReferenceNumber
- individual item level:
    - ItemInfo1 (accessrestrict)