### PR TITLE
Swap unpkg CDN for jsDelivr

### DIFF
--- a/.github/workflows/build-development-branch.yml
+++ b/.github/workflows/build-development-branch.yml
@@ -2,7 +2,7 @@ name: Build latest from whatever side branch
 
 on:
   push:
-    branches: [ quick_fixes ]
+    branches: [ CDN-swap ]
 jobs:
   build-testing:
     runs-on: ubuntu-latest

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -35,9 +35,9 @@
     <meta property="og:title" content="<%= render_page_title %>"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
-    <link href="https://unpkg.com/@umich-lib/web@1/umich-lib.css" rel="stylesheet"/>
-    <script type="module" src="https://unpkg.com/@umich-lib/web@1/dist/umich-lib/umich-lib.esm.js"></script>
-    <script nomodule src="https://unpkg.com/@umich-lib/web@1/dist/umich-lib/umich-lib.js"></script>
+      <link href="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/umich-lib.css" rel="stylesheet"/>
+      <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@1.3.0/dist/umich-lib/umich-lib.esm.js"></script>
+      <script nomodule src="https://cdn.jsdelivr.net/npm/@umich-lib/components@1.1.0/dist/umich-lib/umich-lib.js"></script>
 
   </head>
   <body class="<%= render_body_class %>">


### PR DESCRIPTION
## What's New

The Design System migrated our CSS and web component packages from unpkg to jsDelivr. The old CDN was not being maintained and jsDelivr is actively maintained, has a multi-CDN architecture, and is backed by Cloudflare in our region.

ArcLight development is currently using unpkg and was the last property to be migrated. Unpkg has been down intermittently and is having loading issues this morning (October 28th) so this is a priority fix to deploy. This affects findingaids.lib, staging, and testing.

### Tested

- [X] Chrome
- [X] Safari
- [X] Firefox
- [X] Edge