### PR TITLE
DCP2-408 and DCP2-297 for updating and styling footer

### DIFF
--- a/app/assets/stylesheets/umich-arclight/_footer.scss
+++ b/app/assets/stylesheets/umich-arclight/_footer.scss
@@ -1,16 +1,19 @@
 .footer {
   background: var(--color-blue-400);
 }
+
 .footer ul {
   list-style: none;
   margin: 0;
   padding: 0;
 }
+
 .footer ul a {
-  display: inline-block;
   padding: var(--space-x-small) 0;
   text-decoration: none;
   text-decoration-thickness: 0px;
+  display: flex;
+  align-items: center;
 }
 
 .footer ul a span:hover {
@@ -59,12 +62,15 @@
   color: var(--color-blue-200);
   padding: var(--space-medium) 0;
 }
+
 .footer__disclaimer a {
   color: var(--color-blue-200);
 }
+
 .footer__disclaimer p {
   margin: 0;
 }
+
 @media screen and (min-width: 820px) {
   .footer__disclaimer p {
     display: inline-block;

--- a/app/assets/stylesheets/umich-arclight/_utilities.scss
+++ b/app/assets/stylesheets/umich-arclight/_utilities.scss
@@ -21,3 +21,7 @@
 .needs-changed {
   border: 2px solid red;
 }
+
+.display-none {
+  display: none;
+}

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -53,7 +53,7 @@
             <span>About Digital Content and Collections</span>
           </a>
         </li>
-        <li> <a href="#">
+        <li class="display-none"> <a href="#">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" role="img" >
           <path d="M0 0h24v24H0z" fill="none" />
           <path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z" />

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,65 +2,33 @@
 <%# Last checked for updates: Blacklight v7.9 %>
 <%# https://github.com/projectblacklight/blacklight/blob/master/app/views/shared/_footer.html.erb #%>
 
-<footer class="[ footer ]">
+<footer class="footer">
 <div class="viewport-container">
-  <div class="[ footer__content ]">
+  <div class="footer__content">
     <section>
       <h2>University of Michigan Library</h2>
       <ul>
         <li>
-          <a href="#">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              focusable="false"
-              role="img"
-            >
+          <a href="https://lib.umich.edu/">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" role="img">
               <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
             </svg>
-            <span> U-M Library</span></a
-          >
+            <span> U-M Library</span></a>
         </li>
         <li>
-          <a href="#">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              height="16"
-              viewBox="0 0 24 24"
-              width="16"
-              fill="currentColor"
-              aria-hidden="true"
-              focusable="false"
-              role="img"
-            >
+          <a href="https://www.lib.umich.edu/about-us/about-library/diversity-equity-inclusion-and-accessibility/accessibility">
+            <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="16" fill="currentColor" aria-hidden="true" focusable="false" role="img">
               <path d="M0 0h24v24H0z" fill="none" />
               <circle cx="17" cy="4.54" r="2" />
-              <path
-                d="M14 17h-2c0 1.65-1.35 3-3 3s-3-1.35-3-3 1.35-3 3-3v-2c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5zm3-3.5h-1.86l1.67-3.67C17.42 8.5 16.44 7 14.96 7h-5.2c-.81 0-1.54.47-1.87 1.2L7.22 10l1.92.53L9.79 9H12l-1.83 4.1c-.6 1.33.39 2.9 1.85 2.9H17v5h2v-5.5c0-1.1-.9-2-2-2z"
-              />
+              <path d="M14 17h-2c0 1.65-1.35 3-3 3s-3-1.35-3-3 1.35-3 3-3v-2c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5zm3-3.5h-1.86l1.67-3.67C17.42 8.5 16.44 7 14.96 7h-5.2c-.81 0-1.54.47-1.87 1.2L7.22 10l1.92.53L9.79 9H12l-1.83 4.1c-.6 1.33.39 2.9 1.85 2.9H17v5h2v-5.5c0-1.1-.9-2-2-2z" />
             </svg>
             <span>Accessibility</span></a
           >
         </li>
         <li>
-          <a href="#"
-            ><svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              focusable="false"
-              role="img"
-            >
-              <path
-                d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
-              />
+          <a href="https://www.lib.umich.edu/about-us/policies/library-privacy-statement">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" role="img">
+              <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
             </svg>
             <span>Library Privacy Statement</span></a
           >
@@ -69,139 +37,54 @@
     </section>
 
     <section>
-      <h2>Digital Collections</h2>
+      <h2>Finding Aids</h2>
       <ul>
         <li>
-          <a href="#"
-            ><svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              focusable="false"
-              role="img"
-            >
-              <path
-                d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"
-              />
-            </svg>
-            <span>Browse all digital collections</span></a
-          >
+          <a href="/collections">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" role="img">
+          <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"></path></svg>
+            <span>Browse all finding aids</span></a>
         </li>
         <li>
-          <a href="#"
-            ><svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              focusable="false"
-              role="img"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-              />
-            </svg>
-            <span>About these digital collections</span></a
-          >
-        </li>
-        <li>
-          <a href="#"
-            ><svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              focusable="false"
-              role="img"
-            >
-              <path
-                d="M20 0H4v2h16V0zM4 24h16v-2H4v2zM20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-8 2.75c1.24 0 2.25 1.01 2.25 2.25s-1.01 2.25-2.25 2.25S9.75 10.24 9.75 9 10.76 6.75 12 6.75zM17 17H7v-1.5c0-1.67 3.33-2.5 5-2.5s5 .83 5 2.5V17z"
-              />
-            </svg>
+          <a href="https://www.lib.umich.edu/about-us/our-divisions-and-departments/library-information-technology/digital-content-and">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" role="img">
+          <path d="M20 0H4v2h16V0zM4 24h16v-2H4v2zM20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-8 2.75c1.24 0 2.25 1.01 2.25 2.25s-1.01 2.25-2.25 2.25S9.75 10.24 9.75 9 10.76 6.75 12 6.75zM17 17H7v-1.5c0-1.67 3.33-2.5 5-2.5s5 .83 5 2.5V17z" />
+          </svg>
             <span>About Digital Content and Collections</span>
           </a>
         </li>
-        <li>
-          <a href="#">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              focusable="false"
-              role="img"
-            >
-              <path d="M0 0h24v24H0z" fill="none" />
-              <path
-                d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
-              />
-            </svg>
-
-            <span>How to use this site</span></a
-          >
+        <li> <a href="#">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" role="img" >
+          <path d="M0 0h24v24H0z" fill="none" />
+          <path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z" />
+          </svg>
+          <span>How to use this site</span></a>
         </li>
       </ul>
     </section>
 
-    <section class="[ footer__policies ]">
+    <section class="footer__policies">
       <h2>Policies and Copyright</h2>
       <p>
-        Copyright permissions may be different for each digital
-        collection. Please check the
-        <a href="">Rights and Permissions</a> section on a specific
-        collection for information.
-      </p>
-      <p>
-        <a href="#"
-          >Takedown Policy for Sensitive Information in U-M Digital
-          Collections</a
-        >
+      Copyright permissions may be different for each collection described in a finding aid. Please check the Use & Permissions section on a specific collection for information.
       </p>
     </section>
     <section>
       <h2>Contact Us</h2>
       <ul>
         <li>
-          <a href="#"
-            ><svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-              focusable="false"
-              role="img"
-            >
-              <path
-                d="M19 2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h4l3 3 3-3h4c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-6 16h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 11.9 13 12.5 13 14h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-              />
-            </svg>
-            <span>Ask about this content</span></a
-          >
+          <a href="mailto:dlps-help@umich.edu">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" role="img" focusable="false" aria-hidden="true" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
+            <span>Report problems using this site</span></a>
         </li>
       </ul>
     </section>
   </div>
 </div>
-<div class="[ footer__disclaimer ]">
+<div class="footer__disclaimer">
   <div class="viewport-container">
     <p>&copy; <%= Date.today.year %>, Regents of the University of Michigan</p>
-    <p>
-      Built with the
-      <a href="https://design-system.lib.umich.edu/"
-        >U-M Library Design System</a
-      >
-    </p>
+    <p>Built with <a href="https://github.com/projectblacklight/arclight">ArcLight</a> and the <a href="https://design-system.lib.umich.edu/">U-M Library Design System</a></p>
   </div>
 </div>
 </footer>


### PR DESCRIPTION
## What's New
- Updated footer from [Planned ArcLight/Finding Aids Footer doc](https://docs.google.com/document/d/12gX_-zD6YepUN4m1zU1uDaLAWvdfZzk3l7THUgaxAxM/edit#heading=h.pg8yk4qyvamb)
- Added "ArcLight" to the "Built with footer" disclaimer text

### Tested in:
- [X] Chrome
- [X] Safari
- [X] Firefox
- [X] Edge

### Important note
- "How to use this site" still doesn't have a destination. Should we just remove for now- [Update: list item is hidden using `class="display-none"`
<img width="1285" alt="New ArcLight footer. Dark blue background with white text." src="https://user-images.githubusercontent.com/29953622/199343622-b5e7fd3a-68c2-446f-80ae-1954ff4ee4a7.png">
