### PR TITLE
DCP2-343 - exclude `unittitle[@type="sort"]` from titles

### DIFF
--- a/.github/workflows/build-development-branch.yml
+++ b/.github/workflows/build-development-branch.yml
@@ -2,7 +2,7 @@ name: Build latest from whatever side branch
 
 on:
   push:
-    branches: [ CDN-swap ]
+    branches: [ DCP2-343-exclude_unittitle_sort_type ]
 jobs:
   build-testing:
     runs-on: ubuntu-latest

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -1,5 +1,5 @@
 bhl:
-  name: 'University of Michigan. Bentley Historical Library'
+  name: 'University of Michigan Bentley Historical Library'
   description: 'The Bentley Historical Library collects the materials for and promotes the study of the histories of two great, intertwined institutions, the State of Michigan and the University of Michigan. The Library is open without fee to the public, and we welcome researchers regardless of academic or professional affiliation.'
   visit_note: ''
   building: ''
@@ -39,7 +39,7 @@ bhl:
             field: eadid
             regex: 'umich-bhl-(.*)'
 scrc:
-  name: 'University of Michigan. Special Collections Research Center'
+  name: 'University of Michigan Special Collections Research Center'
   description: 'In keeping with the University Library’s mission to collect, describe, preserve, and make available the record of human knowledge, the Special Collections Research Center acquires, cares for, interprets, and promotes the use of important collections of unique, rare, primary source, and other material in all formats and in a variety of subject areas.'
   visit_note: ''
   building: 'Harlan Hatcher Graduate Library (South)'
@@ -66,7 +66,7 @@ scrc:
     pattern: '-\/\/us::MiU\/\/TEXT us::MiU::(.*)\/\/EN'
     prefix: 'https://quod.lib.umich.edu/s/sclead/eads/'
 clements:
-  name: 'University of Michigan. William L. Clements Library'
+  name: 'University of Michigan William L. Clements Library'
   description: 'The William L. Clements Library is a rare book and manuscript repository located on the University of Michigan’s central campus in Ann Arbor, Michigan.'
   visit_note: ''
   building: ''
@@ -93,7 +93,7 @@ clements:
     pattern: 'us//::miu-c//TXT us::miu-c::(.*.xml)\/\/EN'
     prefix: 'https://quod.lib.umich.edu/c/clementsead/eads/'
 clarke:
-  name: 'Central Michigan University. Clarke Historical Library'
+  name: 'Central Michigan University Clarke Historical Library'
   description: 'The Clarke Historical Library collects, preserves, and promotes collections including the history of Michigan and the Old Northwest Territory, the history of Central Michigan University, as well as other topics.'
   visit_note: ''
   building: ''
@@ -112,7 +112,7 @@ clarke:
     how_to_request: '<a href="clarke@cmich.edu">Contact the Clarke</a> for assistance with collections.'
     how_to_order: 'Please visit <a href="https://www.cmich.edu/research/clarke-historical-library/about/policies#a3">Clarke Digital Reproduction Policies and Fees</a>.'
 vrc:
-  name: 'University of Michigan. History of Art. Visual Resources Collection'
+  name: 'University of Michigan History of Art Visual Resources Collection'
   description: "The VRC maintains nearly two million images of art. The collection's roots are more than 90 years old and developed as a teaching collection to support University of Michigan faculty and students. Through these online finding aids, we hope to help you connect with our vast resources of images of art, architecture, and artifacts."
   visit_note: ''
   building: '45 Tappan Hall'


### PR DESCRIPTION
* update xpaths to ignore unittitle with `type="sort"`

To test:

* download [washingtong_final.xml](https://drive.google.com/file/d/1jPWumeWOLnLiUiiPr6WPKFrO6IIp8Z9p/view?usp=share_link) to the `clements` sample directory
* index with `docker-compose exec -- app bundle exec rake arclight:index FILE=./sample-ead/ead/clements/washingtong_final.xml REPOSITORY_ID=clements`
* the sort title will no longer appear in views

Current staging:

<img width="695" alt="image" src="https://user-images.githubusercontent.com/537867/201364420-96b441a6-1d54-42fe-9fb2-3256bd398394.png">

Fix:

<img width="714" alt="image" src="https://user-images.githubusercontent.com/537867/201364459-0039f722-a876-4bed-986a-e0bc81ecf6e6.png">

