### PR TITLE
Add help link back to footer and link to PDF in Drive

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -53,12 +53,12 @@
             <span>About Digital Content and Collections</span>
           </a>
         </li>
-        <li class="display-none"> <a href="#">
+        <li> <a href="https://drive.google.com/file/d/1suAVoTY9485QQ7XOxae0NKaefAEcd1b9/view">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false" role="img" >
           <path d="M0 0h24v24H0z" fill="none" />
           <path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z" />
           </svg>
-          <span>How to use this site</span></a>
+          <span>How to use this site <span class="sr-only">opens a PDF</span></span></a>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
## What's new

- Displaying the "How to use this site" `li` once again
- Added link to Chris' Help PDF
- Added some screenreader-only text to announce it will open a PDF. This will be removed once the internal Help page(s) are created.

<img width="1221" alt="footer link" src="https://user-images.githubusercontent.com/29953622/205754255-799be989-d90d-4aef-850d-f10fdd2c1388.png" alt="dark blue footer with three columns of text">
