### PR TITLE
DCP2-416 Fix for mark highlighting issues

### DIFF
--- a/app/assets/stylesheets/umich-arclight/_base.scss
+++ b/app/assets/stylesheets/umich-arclight/_base.scss
@@ -15,6 +15,10 @@ a {
   }
 }
 
+h1, h2, h3 {
+  line-height: var(--line-height-heading);
+}
+
 /* ====================== */
 /* BUTTONS     */
 /* ====================== */
@@ -185,6 +189,15 @@ a {
 
 .responsiveTruncate{
   font-size: 1rem;
+}
+
+mark, .mark {
+  padding: 0;
+  background-color: var(--color-maize-200);
+}
+
+.al-document-highlight mark {
+   background-color: var(--color-maize-200);
 }
 
 /* =============++========= */


### PR DESCRIPTION
## What's new
[DCP2-416](https://mlit.atlassian.net/browse/DCP2-416)

- Changed line-height for `h1`, `h2`, and `h3`
- Changed mark highlights to `maize-200`
- Remove padding from `mark`, `.mark`

Tested in: Chrome, Safari, Firefox, and Edge

*After*
<img width="855" alt="maize-200" src="https://user-images.githubusercontent.com/29953622/207419715-7e3c4ae2-63d0-415c-8557-0185d5056b2c.png">

*Before/current production*
<img width="848" alt="Screenshot 2022-12-13 at 1 40 32 PM" src="https://user-images.githubusercontent.com/29953622/207419675-1b850cec-460c-4249-b44e-c1b8c1045def.png">
