### PR TITLE
DCP2-387 + DCP2-388 best practices for featured image fixes

### DIFF
--- a/app/assets/stylesheets/dul-arclight/modules/homepage.scss
+++ b/app/assets/stylesheets/dul-arclight/modules/homepage.scss
@@ -54,7 +54,7 @@
       position: absolute;
       bottom: 0px;
       right: 0px;
-      background-color: rgba(0, 0, 0, 0.4);
+      background-color: rgba(0, 0, 0, 0.65);
       padding: 10px 10px 10px 20px;
       @include media-breakpoint-only(xl) {
         padding-right: 25px;

--- a/app/views/catalog/_home.html.erb
+++ b/app/views/catalog/_home.html.erb
@@ -5,7 +5,7 @@
     <div class="imgback col-md-5 col-lg-6 col-xl-6 hidden-sm-down"></div>
     <div class="imgback imgback-image col-md-5 col-lg-6 col-xl-6 hidden-sm-down"
         style="background-image: url(<%= feature_img_url(@random_feature['image']) %>)">
-      <div class="feature-caption"><%= @random_feature['caption_html'].html_safe %></div>
+      <div class="feature-caption"><span class="sr-only">Featured image: </span><%= @random_feature['caption_html'].html_safe %></div>
     </div>
 
     <div class="col-md-7 col-lg-6 col-xl-5 rl-menu-title">


### PR DESCRIPTION
## What's new

For [DCP2-387](https://mlit.atlassian.net/browse/DCP2-387) + [DCP2-388](https://mlit.atlassian.net/browse/DCP2-388) 
- *Slightly* darken opacity for caption overlay contrast
- Added sr-only text for the caption to describe it as a "Featured image: " to be announced to screen reader.

Parent issue: Warning/best practices a11y fixes