### PR TITLE
DCP2-404 tweaks for link under search, collection breadcrumb font-size, and repository photo 

### DIFF
--- a/app/assets/stylesheets/dul-arclight/dul_styles.scss
+++ b/app/assets/stylesheets/dul-arclight/dul_styles.scss
@@ -282,7 +282,7 @@ a {
 }
 
 .collection-name-wrapper {
-  margin-top: 0.75rem;
+  margin-top: 1.5rem;
   display: block;
   position: relative;
   &:before {
@@ -298,8 +298,8 @@ a {
   a {
     text-decoration: none;
     font-weight: 700;
-    line-height: 1.1;
-    font-size: 1.9rem;
+    line-height: 1.25;
+    font-size: 1.35rem;
 
     i.fas {
       display: block;
@@ -967,6 +967,8 @@ label.toggle-bookmark > span:nth-child(2) {
     align-self: center;
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
+    height: 100%;
+    object-fit: cover;
 
     .img-wrapper {
       height: 10rem;

--- a/app/assets/stylesheets/dul-arclight/modules/homepage.scss
+++ b/app/assets/stylesheets/dul-arclight/modules/homepage.scss
@@ -128,7 +128,7 @@
     .input-group {
       display: inline;
       a {
-        font-size: 15px;
+        font-size: 16px;
         &:not(:first-child) {
           margin-left: 0.6em;
         }

--- a/app/views/catalog/_home.html.erb
+++ b/app/views/catalog/_home.html.erb
@@ -14,7 +14,7 @@
 
       <%= render_search_bar %>
 
-      <div class="intro-buttons mt-3 mb-3">
+      <div class="intro-buttons mt-3 mb-3 d-flex">
         <div id="browse-links" class="btn-group mr-3">
           <%= link_to t('um_arclight.home.browse_all'), arclight_engine.collections_path %>
         </div>


### PR DESCRIPTION
## What's new

- Collection name link in breadcrumb has smaller font-size
- Advanced Search link on home page under search is the same size as "Browse" link and inline with it
- Remove "grey bars" on Repository photo
